### PR TITLE
Allow Settings ScriptableObject to be placed in different folder structures

### DIFF
--- a/Editor/AptabaseImporter.cs
+++ b/Editor/AptabaseImporter.cs
@@ -17,6 +17,8 @@ namespace AptabaseSDK
         {
             try
             {
+                if (AssetDatabase.FindAssets($"t:{nameof(Settings)}").Length > 0) return;
+
                 //check if file exists
                 if (System.IO.File.Exists(PATH))
                     return;


### PR DESCRIPTION
Currently the package only allows Settings to live in the Assets/Aptabase/Resources folder.
Some projects grow in scope and this tight structure can become a problem.

Added initial check on AptabaseImporter during Settings ScriptableObject asset creation to see if the scriptable object is already present in the Unity project
This check also avoids running the entire logic if the settings already exist