### PR TITLE
Update the Event Flushing Mechanism to save in disk

### DIFF
--- a/Runtime/Aptabase.cs
+++ b/Runtime/Aptabase.cs
@@ -103,7 +103,7 @@ namespace AptabaseSDK
             }
             else
             {
-                Flush();
+                _dispatcher.FlushOrSaveToDisk();
                 StopPolling();
             }
         }

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -23,14 +23,18 @@ namespace AptabaseSDK
         
         public Dispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
+            var cacheEvents = PlayerPrefs.GetString(APTDABASE_KEY).FromJson<List<Event>>();
+
             //create event queue
-            _events = new Queue<Event>(PlayerPrefs.GetString("AptabaseEvents").FromJson<List<Event>>() ?? new List<Event>());
+            _events = new Queue<Event>(cacheEvents ?? new List<Event>());
             
             //web request setup information
             _apiURL = $"{baseURL}{EVENTS_ENDPOINT}";
             _appKey = appKey;
             _environment = env;
             _webRequestHelper = new WebRequestHelper();
+
+            PlayerPrefs.DeleteKey(APTDABASE_KEY);
         }
         
         public void Enqueue(Event data)

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -23,10 +23,11 @@ namespace AptabaseSDK
         
         public Dispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
-            var cacheEvents = PlayerPrefs.GetString(APTABASE_KEY).FromJson<List<Event>>();
+            var cachedEventsJson = PlayerPrefs.GetString(APTABASE_KEY);
+            var cacheEvents = string.IsNullOrEmpty(cachedEventsJson) ? new List<Event>() : cachedEventsJson.FromJson<List<Event>>();
 
             //create event queue
-            _events = new Queue<Event>(cacheEvents ?? new List<Event>());
+            _events = new Queue<Event>(cacheEvents);
             
             //web request setup information
             _apiURL = $"{baseURL}{EVENTS_ENDPOINT}";

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -9,7 +9,7 @@ namespace AptabaseSDK
     public class Dispatcher: IDispatcher
     {
         private const string EVENTS_ENDPOINT = "/api/v0/events";
-        private const string APTDABASE_KEY = "AptabaseKey";
+        private const string APTABASE_KEY = "aptabase_key";
         
         private const int MAX_BATCH_SIZE = 25;
         
@@ -23,7 +23,7 @@ namespace AptabaseSDK
         
         public Dispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
-            var cacheEvents = PlayerPrefs.GetString(APTDABASE_KEY).FromJson<List<Event>>();
+            var cacheEvents = PlayerPrefs.GetString(APTABASE_KEY).FromJson<List<Event>>();
 
             //create event queue
             _events = new Queue<Event>(cacheEvents ?? new List<Event>());
@@ -34,7 +34,7 @@ namespace AptabaseSDK
             _environment = env;
             _webRequestHelper = new WebRequestHelper();
 
-            PlayerPrefs.DeleteKey(APTDABASE_KEY);
+            PlayerPrefs.DeleteKey(APTABASE_KEY);
         }
         
         public void Enqueue(Event data)
@@ -86,7 +86,7 @@ namespace AptabaseSDK
         {
             await Flush();
             
-            PlayerPrefs.SetString(APTDABASE_KEY, _events.ToList().ToJson());
+            PlayerPrefs.SetString(APTABASE_KEY, _events.ToList().ToJson());
         }
 
         private static async Task<bool> SendEvents(List<Event> events)

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -87,6 +87,8 @@ namespace AptabaseSDK
 
         private static async Task<bool> SendEvents(List<Event> events)
         {
+            if(Application.internetReachability == NetworkReachability.NotReachable) return false;
+            
             var webRequest = _webRequestHelper.CreateWebRequest(_apiURL, _appKey, _environment, events.ToJson());
             var result = await _webRequestHelper.SendWebRequestAsync(webRequest);
             return result;

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -78,7 +78,7 @@ namespace AptabaseSDK
             _flushInProgress = false;
         }
 
-        public async void FlushOrSaveToDisk()
+        public async Task FlushOrSaveToDisk()
         {
             await Flush();
             

--- a/Runtime/Dispatcher/Dispatcher.cs
+++ b/Runtime/Dispatcher/Dispatcher.cs
@@ -87,7 +87,7 @@ namespace AptabaseSDK
         {
             await Flush();
             
-            PlayerPrefs.SetString(APTABASE_KEY, _events.ToList().ToJson());
+            PlayerPrefs.SetString(APTABASE_KEY, _events.Take(1000).ToList().ToJson());
         }
 
         private static async Task<bool> SendEvents(List<Event> events)

--- a/Runtime/Dispatcher/IDispatcher.cs
+++ b/Runtime/Dispatcher/IDispatcher.cs
@@ -1,11 +1,13 @@
+using System.Threading.Tasks;
+
 namespace AptabaseSDK
 {
     public interface IDispatcher
     {
-        public void Enqueue(Event data);
+        void Enqueue(Event data);
 
-        public Task Flush();
+        Task Flush();
         
-        public void FlushOrSaveToDisk();
+        Task FlushOrSaveToDisk();
     }
 }

--- a/Runtime/Dispatcher/IDispatcher.cs
+++ b/Runtime/Dispatcher/IDispatcher.cs
@@ -4,6 +4,8 @@ namespace AptabaseSDK
     {
         public void Enqueue(Event data);
 
-        public void Flush();
+        public Task Flush();
+        
+        public void FlushOrSaveToDisk();
     }
 }

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -1,12 +1,15 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AptabaseSDK.TinyJson;
+using UnityEngine;
 
 namespace AptabaseSDK
 {
     public class WebGLDispatcher: IDispatcher
     {
         private const string EVENT_ENDPOINT = "/api/v0/event";
+        private const string APTDABASE_KEY = "AptabaseKey";
         
         private static string _apiURL;
         private static WebRequestHelper _webRequestHelper;
@@ -31,7 +34,6 @@ namespace AptabaseSDK
         public void Enqueue(Event data)
         {
             _events.Enqueue(data);
-            Flush();
         }
         
         private void Enqueue(List<Event> data)
@@ -40,7 +42,7 @@ namespace AptabaseSDK
                 _events.Enqueue(eventData);
         }
 
-        public async void Flush()
+        public async Task Flush()
         {
             if (_flushInProgress || _events.Count <= 0)
                 return;
@@ -68,6 +70,13 @@ namespace AptabaseSDK
                 Enqueue(failedEvents);
 
             _flushInProgress = false;
+        }
+
+        public async void FlushOrSaveToDisk()
+        {
+            await Flush();
+            
+            PlayerPrefs.SetString(APTDABASE_KEY, _events.ToList().ToJson());
         }
         
         private static async Task<bool> SendEvent(Event eventData)

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -72,7 +72,7 @@ namespace AptabaseSDK
             _flushInProgress = false;
         }
 
-        public async void FlushOrSaveToDisk()
+        public async Task FlushOrSaveToDisk()
         {
             await Flush();
             

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -21,14 +21,18 @@ namespace AptabaseSDK
         
         public WebGLDispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
+            var cacheEvents = PlayerPrefs.GetString(APTDABASE_KEY).FromJson<List<Event>>();
+
             //create event queue
-            _events = new Queue<Event>();
+            _events = new Queue<Event>(cacheEvents ?? new List<Event>());
             
             //web request setup information
             _apiURL = $"{baseURL}{EVENT_ENDPOINT}";
             _appKey = appKey;
             _environment = env;
             _webRequestHelper = new WebRequestHelper();
+
+            PlayerPrefs.DeleteKey(APTDABASE_KEY);
         }
         
         public void Enqueue(Event data)

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -21,10 +21,11 @@ namespace AptabaseSDK
         
         public WebGLDispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
-            var cacheEvents = PlayerPrefs.GetString(APTABASE_KEY).FromJson<List<Event>>();
+            var cachedEventsJson = PlayerPrefs.GetString(APTABASE_KEY);
+            var cacheEvents = string.IsNullOrEmpty(cachedEventsJson) ? new List<Event>() : cachedEventsJson.FromJson<List<Event>>();
 
             //create event queue
-            _events = new Queue<Event>(cacheEvents ?? new List<Event>());
+            _events = new Queue<Event>(cacheEvents);
             
             //web request setup information
             _apiURL = $"{baseURL}{EVENT_ENDPOINT}";

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -9,7 +9,7 @@ namespace AptabaseSDK
     public class WebGLDispatcher: IDispatcher
     {
         private const string EVENT_ENDPOINT = "/api/v0/event";
-        private const string APTDABASE_KEY = "AptabaseKey";
+        private const string APTABASE_KEY = "aptabase_key";
         
         private static string _apiURL;
         private static WebRequestHelper _webRequestHelper;
@@ -21,7 +21,7 @@ namespace AptabaseSDK
         
         public WebGLDispatcher(string appKey, string baseURL, EnvironmentInfo env)
         {
-            var cacheEvents = PlayerPrefs.GetString(APTDABASE_KEY).FromJson<List<Event>>();
+            var cacheEvents = PlayerPrefs.GetString(APTABASE_KEY).FromJson<List<Event>>();
 
             //create event queue
             _events = new Queue<Event>(cacheEvents ?? new List<Event>());
@@ -32,7 +32,7 @@ namespace AptabaseSDK
             _environment = env;
             _webRequestHelper = new WebRequestHelper();
 
-            PlayerPrefs.DeleteKey(APTDABASE_KEY);
+            PlayerPrefs.DeleteKey(APTABASE_KEY);
         }
         
         public void Enqueue(Event data)
@@ -80,7 +80,7 @@ namespace AptabaseSDK
         {
             await Flush();
             
-            PlayerPrefs.SetString(APTDABASE_KEY, _events.ToList().ToJson());
+            PlayerPrefs.SetString(APTABASE_KEY, _events.ToList().ToJson());
         }
         
         private static async Task<bool> SendEvent(Event eventData)

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -81,6 +81,8 @@ namespace AptabaseSDK
         
         private static async Task<bool> SendEvent(Event eventData)
         {
+            if(Application.internetReachability == NetworkReachability.NotReachable) return false;
+            
             var webRequest = _webRequestHelper.CreateWebRequest(_apiURL, _appKey, _environment, eventData.ToJson());
             var result = await _webRequestHelper.SendWebRequestAsync(webRequest);
             return result;

--- a/Runtime/Dispatcher/WebGLDispatcher.cs
+++ b/Runtime/Dispatcher/WebGLDispatcher.cs
@@ -81,7 +81,7 @@ namespace AptabaseSDK
         {
             await Flush();
             
-            PlayerPrefs.SetString(APTABASE_KEY, _events.ToList().ToJson());
+            PlayerPrefs.SetString(APTABASE_KEY, _events.Take(1000).ToList().ToJson());
         }
         
         private static async Task<bool> SendEvent(Event eventData)


### PR DESCRIPTION
Update the Event Flushing Mechanism to avoid losing events due to network issues or game being closed
- Add the option to save events to disk if they failed to be sent when the game loses focus on the device screen.
- Disable sending events if application is offline
- Added Task return to allow methods to await for event flushing to be done. This is useful in the case events fail and are needed to save localy

Reasoning
- I noticed that the SDK doesn't have "offline" or "lose connection" mode this means that failed events would never be sent if the device lose connection at the end of the session or the player plays the entire session offline
- This is not optimal for mobile games or low stable network devices